### PR TITLE
Use default advertise mode for peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ module "cloud_router" {
   source  = "terraform-google-modules/cloud-router/google"
   version = "~> 0.1"
 
-  name = "example-router"
-  project  = "<PROJECT ID>"
-  region = "us-central1"
+  name    = "example-router"
+  project = "<PROJECT ID>"
+  region  = "us-central1"
   network = "default"
 }
 ```

--- a/examples/interconnect_attachment/main.tf
+++ b/examples/interconnect_attachment/main.tf
@@ -21,23 +21,23 @@ provider "google" {
 module "cloud_router" {
   source = "../../"
 
-  name = "example-router"
-  project  = "example-project"
+  name    = "example-router"
+  project = "example-project"
   network = "default"
-  region = "us-central1"
+  region  = "us-central1"
 
   bgp = {
-    asn = 65000
+    asn               = 65000
     advertised_groups = ["ALL_SUBNETS"]
   }
 }
 
 module "interconnect_attachment" {
   source  = "../../modules/interconnect_attachment"
-  name = "example-attachment"
+  name    = "example-attachment"
   project = "example-project"
-  region = "us-central1"
-  router = module.cloud_router.router.name
+  region  = "us-central1"
+  router  = module.cloud_router.router.name
 
   interconnect = "https://googleapis.com/interconnects/example-interconnect"
 
@@ -46,9 +46,8 @@ module "interconnect_attachment" {
   }
 
   peer = {
-    name = "example-peer"
+    name            = "example-peer"
     peer_ip_address = "169.254.1.2"
-    peer_asn = 65001
-    advertised_groups = ["ALL_SUBNETS"]
+    peer_asn        = 65001
   }
 }

--- a/examples/nat/main.tf
+++ b/examples/nat/main.tf
@@ -21,10 +21,10 @@ provider "google" {
 module "cloud_router" {
   source = "../../"
 
-  name = "example-router"
-  project  = "example-project"
+  name    = "example-router"
+  project = "example-project"
   network = "default"
-  region = "us-central1"
+  region  = "us-central1"
 
   nats = [{
     name = "example-nat"

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -21,8 +21,8 @@ provider "google" {
 module "cloud_router" {
   source = "../../"
 
-  name = "example-router"
-  project  = "example-project"
+  name    = "example-router"
+  project = "example-project"
   network = "default"
-  region = "us-central1"
+  region  = "us-central1"
 }

--- a/modules/interconnect_attachment/main.tf
+++ b/modules/interconnect_attachment/main.tf
@@ -40,6 +40,5 @@ module "interface" {
     peer_ip_address           = var.peer.peer_ip_address
     peer_asn                  = var.peer.peer_asn
     advertised_route_priority = lookup(var.peer, "advertised_route_priority", null)
-    advertised_groups         = var.peer.advertised_groups
   }]
 }

--- a/modules/interconnect_attachment/variables.tf
+++ b/modules/interconnect_attachment/variables.tf
@@ -83,7 +83,6 @@ variable "interface" {
 # - peer_ip_address (string, required): IP address of the BGP interface outside Google Cloud Platform.
 # - peer_asn (string, required): Peer BGP Autonomous System Number (ASN).
 # - advertised_route_priority (number, optional): The priority of routes advertised to this BGP peer.
-# - advertised_groups (string, required): User-specified list of prefix groups to advertise in custom mode
 variable "peer" {
   description = "BGP Peer for this attachment."
   type        = any

--- a/modules/interface/main.tf
+++ b/modules/interface/main.tf
@@ -38,14 +38,4 @@ resource "google_compute_router_peer" "peers" {
   peer_ip_address           = each.value.peer_ip_address
   peer_asn                  = each.value.peer_asn
   advertised_route_priority = lookup(each.value, "advertised_route_priority", null)
-
-  advertise_mode    = "CUSTOM"
-  advertised_groups = lookup(each.value, "advertised_groups", null)
-  dynamic "advertised_ip_ranges" {
-    for_each = lookup(each.value, "advertised_ip_ranges", [])
-    content {
-      range       = advertised_ip_ranges.value.range
-      description = lookup(advertised_ip_ranges.value, "description", null)
-    }
-  }
 }

--- a/modules/interface/variables.tf
+++ b/modules/interface/variables.tf
@@ -60,10 +60,6 @@ variable "interconnect_attachment" {
 # - peer_ip_address (string, required): IP address of the BGP interface outside Google Cloud Platform.
 # - peer_asn (string, required): Peer BGP Autonomous System Number (ASN).
 # - advertised_route_priority (number, optional): The priority of routes advertised to this BGP peer.
-# - advertised_groups (string, required): User-specified list of prefix groups to advertise in custom mode
-# - advertised_ip_ranges (list(object), optional): User-specified list of individual IP ranges to advertise.
-#   - range (string, required):  The IP range to advertise.
-#   - description (string, optional): User-specified description for the IP range.
 variable "peers" {
   type        = any
   description = "BGP peers for this interface."


### PR DESCRIPTION
Currently users are forced to override the router's bgp advertised config in the peer. This should acutally be the default as that is the common pattern desired -- forwarding whatever is set in the bgp config.

The terraform resource is a bit confusing and does not mention this override behaviour, I had to figure it out from the api [docs](https://cloud.google.com/compute/docs/reference/rest/v1/routers):

> Note that this field can only be populated if advertiseMode is CUSTOM and overrides the list defined for the router (in the "bgp" message).

We can add support in the future for custom peer level overrides, but I imagine for the vast majority of customers the router's bgp config should be advertised by the peers.

Also some formatting fixes.