### PR TITLE
automate filling peer ip address

### DIFF
--- a/modules/interconnect_attachment/main.tf
+++ b/modules/interconnect_attachment/main.tf
@@ -36,8 +36,10 @@ module "interface" {
   ip_range                = google_compute_interconnect_attachment.attachment.cloud_router_ip_address
   interconnect_attachment = google_compute_interconnect_attachment.attachment.self_link
   peers = [{
-    name                      = var.peer.name
-    peer_ip_address           = var.peer.peer_ip_address
+    name = var.peer.name
+
+    # Peer IP Address must not contain the subnet mask, else will throw an invalid IP address error.
+    peer_ip_address           = element(split("/", google_compute_interconnect_attachment.attachment.customer_router_ip_address), 0)
     peer_asn                  = var.peer.peer_asn
     advertised_route_priority = lookup(var.peer, "advertised_route_priority", null)
   }]

--- a/modules/interconnect_attachment/outputs.tf
+++ b/modules/interconnect_attachment/outputs.tf
@@ -18,3 +18,8 @@ output "attachment" {
   value       = google_compute_interconnect_attachment.attachment
   description = "The created attachment"
 }
+
+output "customer_router_ip_address" {
+  value       = google_compute_interconnect_attachment.attachment.customer_router_ip_address
+  description = "IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment."
+}

--- a/modules/interconnect_attachment/variables.tf
+++ b/modules/interconnect_attachment/variables.tf
@@ -80,7 +80,6 @@ variable "interface" {
 }
 
 # Type: object, with fields:
-# - peer_ip_address (string, required): IP address of the BGP interface outside Google Cloud Platform.
 # - peer_asn (string, required): Peer BGP Autonomous System Number (ASN).
 # - advertised_route_priority (number, optional): The priority of routes advertised to this BGP peer.
 variable "peer" {


### PR DESCRIPTION
"The VLAN attachment automatically allocates a VLAN ID and BGP peering IP addresses. Use that information to configure your on-premises router and establish a BGP session with Cloud Router."

https://cloud.google.com/interconnect/docs/how-to/dedicated/creating-vlan-attachments