### PR TITLE
feat: Make secondary_ip_range_names field optional

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -44,7 +44,7 @@ resource "google_compute_router_nat" "nats" {
     content {
       name                     = subnetwork.value.name
       source_ip_ranges_to_nat  = subnetwork.value.source_ip_ranges_to_nat
-      secondary_ip_range_names = subnetwork.value.secondary_ip_range_names
+      secondary_ip_range_names = lookup(subnetwork.value, "secondary_ip_range_names", [])
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "bgp" {
 # - subnetworks (list(objects), optional):
 #   - name (string, required): Self-link of subnetwork to NAT.
 #   - source_ip_ranges_to_nat (string, required): List of options for which source IPs in the subnetwork should have NAT enabled.
-#   - secondary_ip_range_names (string, required): List of the secondary ranges of the subnetwork that are allowed to use NAT.
+#   - secondary_ip_range_names (string, optional): List of the secondary ranges of the subnetwork that are allowed to use NAT.
 variable "nats" {
   description = "NATs to deploy on this router."
   type        = any


### PR DESCRIPTION
If the `secondary_ip_range_names` is required, it's not possible to use the `ALL_IP_RANGES` option. This PR fixes that  

```
Error: Error creating RouterNat: googleapi: Error 400: Invalid value for field 'resource.nats[0].subnetworks[0].secondaryIpRangeNames': ''. No secondary IP ranges should be provided if the subnetwork is not configured with LIST_OF_SECONDARY_IP_RANGES., invalid   
```