### PR TITLE
Add ability to specify MTU for vlan_attachment submodule.

### DIFF
--- a/modules/interconnect_attachment/README.md
+++ b/modules/interconnect_attachment/README.md
@@ -9,6 +9,7 @@
 | description | An optional description of this resource | `string` | `null` | no |
 | interconnect | URL of the underlying Interconnect object that this attachment's traffic will traverse through. | `string` | n/a | yes |
 | interface | Interface to deploy for this attachment. | `any` | n/a | yes |
+| mtu | Maximum Transmission Unit (MTU), in bytes, of packets passing through this interconnect attachment. Currently, only 1440 and 1500 are allowed. If not specified, the value will default to 1440. | `string` | `null` | no |
 | name | The name of the interconnect attachment | `string` | n/a | yes |
 | peer | BGP Peer for this attachment. | `any` | n/a | yes |
 | project | The project ID to deploy to | `string` | n/a | yes |

--- a/modules/interconnect_attachment/main.tf
+++ b/modules/interconnect_attachment/main.tf
@@ -24,6 +24,7 @@ resource "google_compute_interconnect_attachment" "attachment" {
   type              = var.type
   description       = var.description
   bandwidth         = var.bandwidth
+  mtu               = var.mtu
   candidate_subnets = var.candidate_subnets
   vlan_tag8021q     = var.vlan_tag8021q
 }

--- a/modules/interconnect_attachment/variables.tf
+++ b/modules/interconnect_attachment/variables.tf
@@ -57,6 +57,12 @@ variable "bandwidth" {
   default     = "BPS_10G"
 }
 
+variable "mtu" {
+  type        = string
+  description = "Maximum Transmission Unit (MTU), in bytes, of packets passing through this interconnect attachment. Currently, only 1440 and 1500 are allowed. If not specified, the value will default to 1440."
+  default     = null
+}
+
 variable "description" {
   type        = string
   description = "An optional description of this resource"


### PR DESCRIPTION
Since the google_compute_interconnect_attachment supports a parameter for specifying the mtu i have added this to the submodule.
The default is set to "null", meaning a default value of 1440 will be picked up by the provider.

Fixes #29