### PR TITLE
fix!: use google default values when specific settings omitted

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -27,13 +27,13 @@ resource "google_compute_router_nat" "nats" {
   nat_ip_allocate_option             = lookup(each.value, "nat_ip_allocate_option", length(lookup(each.value, "nat_ips", [])) > 0 ? "MANUAL_ONLY" : "AUTO_ONLY")
   source_subnetwork_ip_ranges_to_nat = lookup(each.value, "source_subnetwork_ip_ranges_to_nat", "ALL_SUBNETWORKS_ALL_IP_RANGES")
 
-  nat_ips                             = lookup(each.value, "nat_ips", [])
-  min_ports_per_vm                    = lookup(each.value, "min_ports_per_vm", 0)
-  udp_idle_timeout_sec                = lookup(each.value, "udp_idle_timeout_sec", 30)
-  icmp_idle_timeout_sec               = lookup(each.value, "icmp_idle_timeout_sec", 30)
-  tcp_established_idle_timeout_sec    = lookup(each.value, "tcp_established_idle_timeout_sec", 1200)
-  tcp_transitory_idle_timeout_sec     = lookup(each.value, "tcp_transitory_idle_timeout_sec", 30)
-  enable_endpoint_independent_mapping = lookup(each.value, "enable_endpoint_independent_mapping", true)
+  nat_ips                             = lookup(each.value, "nat_ips", null)
+  min_ports_per_vm                    = lookup(each.value, "min_ports_per_vm", null)
+  udp_idle_timeout_sec                = lookup(each.value, "udp_idle_timeout_sec", null)
+  icmp_idle_timeout_sec               = lookup(each.value, "icmp_idle_timeout_sec", null)
+  tcp_established_idle_timeout_sec    = lookup(each.value, "tcp_established_idle_timeout_sec", null)
+  tcp_transitory_idle_timeout_sec     = lookup(each.value, "tcp_transitory_idle_timeout_sec", null)
+  enable_endpoint_independent_mapping = lookup(each.value, "enable_endpoint_independent_mapping", null)
 
   log_config {
     enable = true
@@ -45,7 +45,7 @@ resource "google_compute_router_nat" "nats" {
     content {
       name                     = subnetwork.value.name
       source_ip_ranges_to_nat  = subnetwork.value.source_ip_ranges_to_nat
-      secondary_ip_range_names = lookup(subnetwork.value, "secondary_ip_range_names", [])
+      secondary_ip_range_names = lookup(subnetwork.value, "secondary_ip_range_names", null)
     }
   }
 }


### PR DESCRIPTION
The module is not using the default NAT configuration when values are omitted; `null` values are not passed to the resource therefore the defaults automatically apply ([ref](https://www.terraform.io/language/expressions/types#null)).