### PR TITLE
feat: support max_ports_per_vm in NAT config

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -29,6 +29,7 @@ resource "google_compute_router_nat" "nats" {
 
   nat_ips                             = lookup(each.value, "nat_ips", null)
   min_ports_per_vm                    = lookup(each.value, "min_ports_per_vm", null)
+  max_ports_per_vm                    = lookup(each.value, "max_ports_per_vm", null)
   udp_idle_timeout_sec                = lookup(each.value, "udp_idle_timeout_sec", null)
   icmp_idle_timeout_sec               = lookup(each.value, "icmp_idle_timeout_sec", null)
   tcp_established_idle_timeout_sec    = lookup(each.value, "tcp_established_idle_timeout_sec", null)

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,7 @@ variable "bgp" {
 # - source_subnetwork_ip_ranges_to_nat (string, optional): How NAT should be configured per Subnetwork. Defaults to ALL_SUBNETWORKS_ALL_IP_RANGES.
 # - nat_ips (list(number), optional): Self-links of NAT IPs.
 # - min_ports_per_vm (number, optional): Minimum number of ports allocated to a VM from this NAT.
+# - max_ports_per_vm (number, optional): Maximum number of ports allocated to a VM from this NAT. This field can only be set when enableDynamicPortAllocation is enabled.
 # - udp_idle_timeout_sec (number, optional): Timeout (in seconds) for UDP connections. Defaults to 30s if not set.
 # - icmp_idle_timeout_sec (number, optional): Timeout (in seconds) for ICMP connections. Defaults to 30s if not set.
 # - tcp_established_idle_timeout_sec (number, optional): Timeout (in seconds) for TCP established connections. Defaults to 1200s if not set.

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.22, < 5.0"
+      version = ">= 4.27, < 5.0"
     }
   }
 


### PR DESCRIPTION
Now that the module supports DPA we should also support the max ports config option.

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat#max_ports_per_vm