### PR TITLE
Allow nat to have logs disabled. 

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -38,7 +38,7 @@ resource "google_compute_router_nat" "nats" {
   enable_dynamic_port_allocation      = lookup(each.value, "enable_dynamic_port_allocation", null)
 
   log_config {
-    enable = true
+    enable = lookup(lookup(each.value, "log_config", {}), "enable", true)
     filter = lookup(lookup(each.value, "log_config", {}), "filter", "ALL")
   }
 


### PR DESCRIPTION
This change allows the user to set the log_config for a nat to "disabled" if desired. 

I'm unfortunately able to test at this time, it'd be great if a maintainer could execute them for me. 

Fix taken from #26 