### PR TITLE
chore: update title for interrconnect_attachment and regenerate metadata

### DIFF
--- a/modules/interconnect_attachment/README.md
+++ b/modules/interconnect_attachment/README.md
@@ -1,3 +1,5 @@
+# Cloud Router Terraform Module
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/modules/interconnect_attachment/metadata.yaml
+++ b/modules/interconnect_attachment/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/modules/interconnect_attachment/metadata.yaml
+++ b/modules/interconnect_attachment/metadata.yaml
@@ -1,0 +1,108 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-cloud-router-interconnect-attachment
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Cloud Router Terraform Module
+    source:
+      repo: https://github.com/terraform-google-modules/terraform-google-cloud-router.git
+      sourceType: git
+      dir: /modules/interconnect_attachment
+    version: 6.0.2
+    actuationTool:
+      flavor: Terraform
+      version: ">= 1.3"
+    description: {}
+  content:
+    examples:
+      - name: interconnect_attachment
+        location: examples/interconnect_attachment
+      - name: nat
+        location: examples/nat
+      - name: simple_example
+        location: examples/simple_example
+  interfaces:
+    variables:
+      - name: admin_enabled
+        description: Whether the VLAN attachment is enabled or disabled
+        varType: bool
+        defaultValue: true
+      - name: bandwidth
+        description: Provisioned bandwidth capacity for the interconnect attachment
+        varType: string
+        defaultValue: BPS_10G
+      - name: candidate_subnets
+        description: Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16) and must be /29 or shorter (/28, /27, etc).
+        varType: list(string)
+      - name: description
+        description: An optional description of this resource
+        varType: string
+      - name: interconnect
+        description: URL of the underlying Interconnect object that this attachment's traffic will traverse through.
+        varType: string
+        required: true
+      - name: interface
+        description: Interface to deploy for this attachment.
+        varType: |-
+          object({
+              name = string
+            })
+        required: true
+      - name: mtu
+        description: Maximum Transmission Unit (MTU), in bytes, of packets passing through this interconnect attachment. Currently, only 1440 and 1500 are allowed. If not specified, the value will default to 1440.
+        varType: string
+      - name: name
+        description: The name of the interconnect attachment
+        varType: string
+        required: true
+      - name: peer
+        description: BGP Peer for this attachment.
+        varType: |-
+          object({
+              name                      = string
+              peer_asn                  = string
+              advertised_route_priority = optional(number)
+              bfd = optional(object({
+                session_initialization_mode = string
+                min_transmit_interval       = optional(number)
+                min_receive_interval        = optional(number)
+                multiplier                  = optional(number)
+              }))
+            })
+        required: true
+      - name: project
+        description: The project ID to deploy to
+        varType: string
+        required: true
+      - name: region
+        description: Region where the attachment resides
+        varType: string
+        required: true
+      - name: router
+        description: Name of the router the attachment resides
+        varType: string
+        required: true
+      - name: type
+        description: The type of InterconnectAttachment you wish to create
+        varType: string
+        defaultValue: DEDICATED
+      - name: vlan_tag8021q
+        description: The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094.
+        varType: string
+    outputs:
+      - name: attachment
+        description: The created attachment
+      - name: customer_router_ip_address
+        description: IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment.
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - serviceusage.googleapis.com
+      - compute.googleapis.com


### PR DESCRIPTION
Readme file in `interconnect_attachment` submodule does not contain title.
As a result, the command to regenerate metadata `cft blueprint metadata -f` fails.
