### PR TITLE
fix(TPG >= 5.12)!: update interface module provider min version to 5.12

### DIFF
--- a/modules/interface/versions.tf
+++ b/modules/interface/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.51, < 7"
+      version = ">= 5.12, < 7"
     }
   }
 


### PR DESCRIPTION
The `md5_authentication_key` support was just added to `modules/interface` in #149, but the related resource field is only available in `google-terraform-provider` version [5.12](https://github.com/hashicorp/terraform-provider-google/releases/tag/v5.12.0) and above. Need to update the min version.