### PR TITLE
fix: Remove duplicate title in metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,7 +21,6 @@ metadata:
 spec:
   info:
     title: "Cloud Router"
-    title: "Cloud Router"
     source:
       repo: https://github.com/terraform-google-modules/terraform-google-cloud-router.git
       sourceType: git


### PR DESCRIPTION
Removes the redundant `title` field from the `spec.info` section in `metadata.yaml`.

The `title` key was accidentally duplicated. This commit corrects the metadata to have only one `title` entry.
